### PR TITLE
unpin env

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,37 +1,33 @@
 name: esip-tech-dive
 channels:
   - conda-forge
+  - defaults
 dependencies:
-  - conda=4.6.3
+  - python=3.7
   - nomkl
-  - s3fs=0.2.0
-  - gcsfs=0.2.0
-  - intake=0.4.1
-  - intake-xarray=0.3.0
-  - msgpack-python=0.6.1
-  - curl=7.64
-  - python=3.6
-  - xarray=0.11.3
-  - zarr=2.2.0 
-  - dask=1.1
-  - distributed=1.25.2
-  - dask-kubernetes=0.8.0
-  - matplotlib=3.0
-  - nbserverproxy=0.8.8
-  - jupyter=1.0.0
-  - ipywidgets=7.4.2
-  - graphviz=2.38
-  - jupyterlab=0.35.4
-  - libgdal=2.4.0
-  - boto3=1.9.91
-  - hvplot=0.4.0
-  - geoviews-core=1.6.2
-  - ipyleaflet=0.8.1
-  - datashader=0.6.9
-  - requests=2.21.0
-  - pandas=0.24.1
-  - geopandas=0.4.0
-  - rasterio=1.0.18
-  - pip:
-    - sat-search==0.2.0
-    - dask-labextension==0.3.1
+  - boto3
+  - dask
+  - dask-kubernetes
+  - dask-labextension
+  - datashader
+  - distributed
+  - gcsfs
+  - geopandas
+  - geoviews-core
+  - python-graphviz
+  - hvplot
+  - intake
+  - intake-xarray
+  - ipyleaflet
+  - ipywidgets
+  - jupyter
+  - jupyterlab
+  - matplotlib
+  - msgpack-python
+  - nbserverproxy
+  - rasterio
+  - requests
+  - s3fs
+  - sat-search
+  - xarray
+  - zarr


### PR DESCRIPTION
@rsignell-usgs this should help you get this working again.

@scottyhq I unpin most of the dependencies and I'm letting conda do the work here. With latest conda the solver situation is better and you should pin only when really needed or to freeze a deployment.

Also, I removed a few dependency-of-a-dependency, `libgdal`, to let the high level dependency, `rasterio`, pull whatever version of gdal it needs to work.